### PR TITLE
chat_spaceのデータベース実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,55 @@
 # README
 
+##usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|text|null: false|
+|email|text|null: false, unique: true|
+|password|string|null: false|
+
+### Association
+- has_many :groups, through: :groups_users
+- has_many :messages
+
+####groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+|group_users_id|integer|null: false, foreign_key: true|
+|messages_id|integer|null: false, foreign_key: true|
+
+##### Association
+- has_many :messages
+- has_many :users, through: :groups_users
+
+
+###### groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+####### Association
+- belongs_to :group
+- belongs_to :user
+
+
+######## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+
+######### Association
+- belongs_to :user
+- belongs_to :group
+
+
+
+
 This README would normally document whatever steps are necessary to get the
 application up and running.
 

--- a/README.md
+++ b/README.md
@@ -3,32 +3,32 @@
 ##usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|text|null: false|
+|name|text|null: false, index: true|
 |email|text|null: false, unique: true|
 |password|string|null: false|
 
 ### Association
 - has_many :groups, through: :groups_users
 - has_many :messages
+- has_many :groups_users
 
 ####groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
-|group_users_id|integer|null: false, foreign_key: true|
-|messages_id|integer|null: false, foreign_key: true|
+|name|string|null: false|
 
 ##### Association
 - has_many :messages
 - has_many :users, through: :groups_users
+- has_many :groups_users
 
 
 ###### groups_usersテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ####### Association
 - belongs_to :group
@@ -38,10 +38,10 @@
 ######## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |image|string||
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
 
 ######### Association
 - belongs_to :user


### PR DESCRIPTION
#what
chat_spaceのデータベース設計をするためにREADME.mdに記載。
usersテーブルを作成し、nameカラム、emailカラム、passwordカラムを実装
groupsテーブルを作成し、group_nameカラム、group_users_idカラム、messages_idカラムを実装
group_usersテーブルを作成し、user_idカラム、group_idカラムを実装
messagesテーブルを作成し、bodyカラム、imageカラム、group_idカラム、user_idカラムを実装



#why
ユーザーのサインインの際に名前、メール、パスワードの入力が必要だったため、
その情報を保存するusersテーブルを作成し、対応するカラムを作成しました。

グループ作成する際にグループ名、メンバー名が、グループで誰がどのような発言をしたか保存が必要があったため、その情報を保存するgroupsテーブルを作成し、対応するカラムを作成しました。

ユーザーテーブルとグループテーブルはお互い多対多になってるので
中間テーブルであるgroup_usersテーブルを作成し、対応するカラムを作成しました。

メッセージを作成する際、文章と写真が送信できる、またその際に誰がどのような発言をしたか保存する必要があったため、messagesテーブルを作成し、対応するカラムを作成しました。


ユーザーテーブルはグループテーブル、メッセージテーブルを所持しており、グループテーブルは中間テーブルgroup_usersテーブルを経由するためアソシエーションを実装。

グループテーブルはユーザーテーブル、メッセージテーブルを所持おり、ユーザーテーブルは中間テーブルgroup_usersテーブルを経由するためアソシエーションを実装。

メッセージテーブルはユーザーテーブル、グループテーブルに所属しているためアソシエーションを実装。

中間テーブルgroup_usersテーブルはユーザーテーブル、グループテーブルに所属しているため、アソシエーションを実装。